### PR TITLE
Fixed relation dict value of "knee" in EPIC_leg_01 which causes building failure in certain cases

### DIFF
--- a/scripts/mgear/shifter_epic_components/EPIC_leg_01/__init__.py
+++ b/scripts/mgear/shifter_epic_components/EPIC_leg_01/__init__.py
@@ -733,7 +733,7 @@ class Component(component.Main):
     def setRelation(self):
         """Set the relation beetween object from guide to rig"""
         self.relatives["root"] = self.div_cns[0]
-        self.relatives["knee"] = self.div_cns[self.settings["div0"] + 2]
+        self.relatives["knee"] = self.div_cns[self.settings["div0"] + 1]
         self.relatives["ankle"] = self.div_cns[-1]
         self.relatives["eff"] = self.end_ref
 


### PR DESCRIPTION
Caught this when I tried to build an EPIC_leg_01 with 0 in both divisions.
When only one knee joint exists, the value of relation["knee"] should be the value of div0 +1, not +2.
![2021-03-17_17h54_35](https://user-images.githubusercontent.com/3250174/111444720-03730300-874e-11eb-879d-ecc162243ace.jpg)
